### PR TITLE
Add redirects from latest Internet trawl of dead links

### DIFF
--- a/external-links.txt
+++ b/external-links.txt
@@ -7,3 +7,9 @@ https://www.patrickstevens.co.uk/posts/2016-04-13-independence-of-choice/
 https://www.patrickstevens.co.uk/posts/2016-04-08-another-monty-hall-explanation/
 https://www.patrickstevens.co.uk/misc/AdjointFunctorTheorems/AdjointFunctorTheorems.pdf
 https://www.patrickstevens.co.uk/posts/2021-02-20-in-praise-of-dry-run/
+http://www.patrickstevens.co.uk/wordpress/archives/364
+http://www.patrickstevens.co.uk/wordpress/archives/379
+http://www.patrickstevens.co.uk/wordpress/archives/474
+http://www.patrickstevens.co.uk/wordpress/archives/584
+https://www.patrickstevens.co.uk/posts/2020-10-23-anki-learning/
+https://www.patrickstevens.co.uk/sequentially-compact-iff-compact/

--- a/hugo/content/posts/2013-07-29-stumbled-across-29-july-2013.md
+++ b/hugo/content/posts/2013-07-29-stumbled-across-29-july-2013.md
@@ -8,6 +8,7 @@ date: "2013-07-29T00:00:00Z"
 aliases:
 - /stumbled_across/stumbled-across-2/
 - /stumbled-across-29-july-2013/
+- /wordpress/archives/241/
 title: Stumbled across 29th July 2013
 ---
 *   Hehe: <http://www.pixartheory.com/>

--- a/hugo/content/posts/2013-07-30-on-to-do-lists-as-direction-in-life.md
+++ b/hugo/content/posts/2013-07-30-on-to-do-lists-as-direction-in-life.md
@@ -8,6 +8,7 @@ date: "2013-07-30T00:00:00Z"
 aliases:
 - /uncategorized/on-to-do-lists-as-direction-in-life/
 - /on-to-do-lists-as-direction-in-life/
+- /wordpress/archives/268/
 title: On to-do lists as direction in life
 ---
 [Getting Things Done](https://en.wikipedia.org/wiki/Getting_Things_Done) has gathered something of a [cult following](http://web.archive.org/web/20130428015707/http://www.wired.com/techbiz/people/magazine/15-10/ff_allen? "Wired article on GTD") [archived due to [link rot][1]] since its inception. As a way of getting things done, it's pretty good - separate tasks out into small bits on your to-do list so that you have mental room free to consider the bigger picture. However, there's a certain aspect of to-do lists that I've not really seen mentioned before, and which I find to be really helpful.

--- a/hugo/content/posts/2013-08-04-new-computer-setup.md
+++ b/hugo/content/posts/2013-08-04-new-computer-setup.md
@@ -8,6 +8,7 @@ date: "2013-08-04T00:00:00Z"
 aliases:
 - /uncategorized/new-computer-setup/
 - /new-computer-setup/
+- /wordpress/archives/36
 title: New computer setup
 ---
 

--- a/hugo/content/posts/2013-08-04-stumbled-across-4-august-2013.md
+++ b/hugo/content/posts/2013-08-04-stumbled-across-4-august-2013.md
@@ -8,6 +8,7 @@ date: "2013-08-04T00:00:00Z"
 aliases:
 - /stumbled_across/stumbled-across-3/
 - /stumbled-across-4-august-2013/
+- /wordpress/archives/267/
 title: Stumbled across 4th August 2013
 ---
 *   An ad developer has misgivings: <http://seriouspony.com/blog/2013/7/24/your-app-makes-me-fat>

--- a/hugo/content/posts/2013-08-11-stumbled-across-11th-august-2013.md
+++ b/hugo/content/posts/2013-08-11-stumbled-across-11th-august-2013.md
@@ -8,6 +8,7 @@ date: "2013-08-11T00:00:00Z"
 aliases:
 - /stumbled_across/stumbled-across-11th-august-2013/
 - /stumbled-across-11th-august-2013/
+- /wordpress/archives/301/
 title: Stumbled across 11th August 2013
 ---
 *   A thousand times this (EDIT 2022: the link is dead and I have no idea what I was referring to).

--- a/hugo/content/posts/2013-08-18-thinking-styles.md
+++ b/hugo/content/posts/2013-08-18-thinking-styles.md
@@ -9,6 +9,7 @@ math: true
 aliases:
 - /psychology/thinking-styles/
 - /thinking-styles/
+- /wordpress/archives/335/
 title: Thinking styles
 ---
 All the way back into primary school (ages 4 to 11 years old, in case a non-Brit is reading this), we have been told repeatedly that "people learn things in different ways". There were two years in primary school when I had a teacher who was very into [Six Thinking Hats](https://en.wikipedia.org/wiki/Six_Thinking_Hats) (leading to the worst outbreak of headlice I've ever encountered) and [mind maps](https://en.wikipedia.org/wiki/Mind_map). I never understood mind maps, and whenever we were told to create a mind map, I'd make mine as linear and boxy as possible, out of simple frustration with the pointless task of making a picture of something that I already had perfectly well-set-out in my mind. I quickly learnt to correlate "making a mind map" with "being slow and inefficient at thinking". (This was back when my memory was still exceptionally good, so I wasn't really learning much at school - having read, and therefore memorised, a good children's encyclopaedia was enough for me - and hence relative to me, pretty much everyone else was slow and inefficient, because I'd already learnt the material.)

--- a/hugo/content/posts/2013-08-21-my-experiences-with-flow.md
+++ b/hugo/content/posts/2013-08-21-my-experiences-with-flow.md
@@ -8,6 +8,7 @@ date: "2013-08-21T00:00:00Z"
 aliases:
 - /psychology/flow/
 - /my-experiences-with-flow/
+- /wordpress/archives/326/
 title: My experiences with flow
 ---
 I'm in the middle of reading [Flow](https://en.wikipedia.org/wiki/Flow_(psychology)), by [Mihály Csíkszentmihályi][1], and so far, I love it. It describes the "[flow state](https://en.wikipedia.org/wiki/Flow_%28psychology%29)" of consciousness, that state of "everything is irrelevant except for the task at hand" in which time flies past without your noticing, and you don't notice hunger or thirst or people moving around you. Flow can be induced when performing a difficult task which lies within your abilities, where immediate feedback is provided. I, at least, feel characteristically exhausted after coming out of a long period of flow - but it's a good kind of mental exhaustion, much as the tiredness after a long swim is a good kind of physical exhaustion (in contrast to tiredness-after-a-long-day-of-doing-nothing, which feels sort of lazier and unwholesome). The Wikipedia page is a good enough explanation of flow that I will not describe it further here.

--- a/hugo/content/posts/2013-08-22-how-to-punt-in-cambridge.md
+++ b/hugo/content/posts/2013-08-22-how-to-punt-in-cambridge.md
@@ -8,6 +8,7 @@ date: "2013-08-22T00:00:00Z"
 aliases:
 - /uncategorized/how-to-punt-in-cambridge/
 - /how-to-punt-in-cambridge/
+- /wordpress/archives/345/
 title: How to punt in Cambridge
 ---
 [When in Cambridge][1]…

--- a/hugo/content/posts/2013-08-24-stumbled-across-24-august-2013.md
+++ b/hugo/content/posts/2013-08-24-stumbled-across-24-august-2013.md
@@ -8,6 +8,7 @@ date: "2013-08-24T00:00:00Z"
 aliases:
 - /stumbled_across/stumbled-across-4/
 - /stumbled-across-24-august-2013/
+- /wordpress/archives/329/
 title: Stumbled across 24th August 2013
 ---
 *   The much-vaunted Hyperloop looks really cool, if it could ever be built: <https://arstechnica.com/business/2013/08/hyperloop-a-theoretical-760-mph-transit-system-made-of-sun-air-and-magnets/>

--- a/hugo/content/posts/2013-09-13-stumbled-across-14th-september-2013.md
+++ b/hugo/content/posts/2013-09-13-stumbled-across-14th-september-2013.md
@@ -8,6 +8,7 @@ date: "2013-09-13T00:00:00Z"
 aliases:
 - /stumbled_across/stumbled-across-14th-september-2013/
 - /stumbled-across-14th-september-2013/
+- /wordpress/archives/362/
 title: Stumbled across 14th September 2013
 ---
 *  On the merits of silence (I wholeheartedly agree): <http://www.nytimes.com/2013/08/25/opinion/sunday/im-thinking-please-be-quiet.html>

--- a/hugo/content/posts/2013-09-21-how-to-prove-that-you-are-a-god.md
+++ b/hugo/content/posts/2013-09-21-how-to-prove-that-you-are-a-god.md
@@ -8,6 +8,7 @@ date: "2013-09-21T00:00:00Z"
 aliases:
 - /uncategorized/how-to-prove-that-you-are-a-god/
 - /how-to-prove-that-you-are-a-god/
+- /wordpress/archives/434/
 title: How to prove that you are a god
 ---
 I came across an interesting question while reading the blog of [Scott Aaronson][1] today. The question was as follows:

--- a/hugo/content/posts/2013-10-10-plot-armour.md
+++ b/hugo/content/posts/2013-10-10-plot-armour.md
@@ -8,6 +8,7 @@ date: "2013-10-10T00:00:00Z"
 aliases:
 - /creative/plot-armour/
 - /plot-armour/
+- /wordpress/archives/445/
 title: Plot Armour
 ---
 *Wherein I dabble in parodic fiction. The title refers to the TV Tropes page on [Plot Armour][1], but don't follow that link unless you first resolve not to click on any links on that page. TV Tropes is the hardest extant website from which to escape.*

--- a/hugo/content/posts/2013-10-11-meaning-what-you-say.md
+++ b/hugo/content/posts/2013-10-11-meaning-what-you-say.md
@@ -8,6 +8,7 @@ date: "2013-10-11T00:00:00Z"
 aliases:
 - /uncategorized/meaning-what-you-say/
 - /meaning-what-you-say/
+- /wordpress/archives/450
 title: Meaning what you say
 ---
 In conversation with (say, for the purposes of propagating a sterotype) humanities students, I am often struck by how imprecisely language is used, and how much confusion arises therefrom. A case in point:

--- a/hugo/content/posts/2013-10-13-training-away-mental-bias.md
+++ b/hugo/content/posts/2013-10-13-training-away-mental-bias.md
@@ -8,6 +8,7 @@ date: "2013-10-13T00:00:00Z"
 aliases:
 - /psychology/training-away-mental-bias/
 - /training-away-mental-bias/
+- /wordpress/archives/455
 title: Training away mental bias
 ---
 *In which I recount an experiment I have been performing. Please be aware that in this article I am in "[meaning what I say][1]" mode.*

--- a/hugo/content/posts/2013-10-20-the-ravenous.md
+++ b/hugo/content/posts/2013-10-20-the-ravenous.md
@@ -8,6 +8,7 @@ date: "2013-10-20T00:00:00Z"
 aliases:
 - /creative/the-ravenous/
 - /the-ravenous/
+- /wordpress/archives/462/
 title: The Ravenous
 sidenotes: true
 ---

--- a/hugo/content/posts/2013-10-24-how-to-do-analysis-questions.md
+++ b/hugo/content/posts/2013-10-24-how-to-do-analysis-questions.md
@@ -10,6 +10,8 @@ math: true
 aliases:
 - /mathematical_summary/how-to-do-analysis-questions/
 - /how-to-do-analysis-questions/
+- /archives/474/
+- /wordpress/archives/474/
 title: How to do Analysis questions
 ---
 This post is for posterity, made shortly after [Dr Paul Russell][1] lectured Analysis II in Part IB of the Maths Tripos at Cambridge. In particular, he demonstrated a way of doing certain basic questions. It may be useful to people who are only just starting the study of analysis and/or who are doing example sheets in it.

--- a/hugo/content/posts/2013-11-07-my-quest-for-a-new-phone.md
+++ b/hugo/content/posts/2013-11-07-my-quest-for-a-new-phone.md
@@ -8,6 +8,7 @@ date: "2013-11-07T00:00:00Z"
 aliases:
 - /uncategorized/my-quest-for-a-new-phone/
 - /my-quest-for-a-new-phone/
+- /wordpress/archives/486/
 title: My quest for a new phone
 ---
 *This post is unfinished, and may never be finished - I have decided that the Nexus 5 is sufficiently cheap, nice-looking and future-proof to outweigh the boredom of continuing the research here, especially given that such research by necessity has a very short lifespan. I am one of those people who hates shopping with a fiery passion.*

--- a/hugo/content/posts/2013-11-12-markov-chain-card-trick.md
+++ b/hugo/content/posts/2013-11-12-markov-chain-card-trick.md
@@ -9,6 +9,7 @@ math: true
 aliases:
 - /mathematical_summary/markov-chain-card-trick/
 - /markov-chain-card-trick/
+- /wordpress/archives/500/
 title: Markov Chain card trick
 ---
 In my latest lecture on [Markov Chains][1] in Part IB of the Mathematical Tripos, our lecturer showed us a very nice little application of the theorem that "if a discrete-time chain is aperiodic, irreducible and positive-recurrent, then there is an invariant distribution to which the chain tends as time increases". In particular, let \\(X\\) be a Markov chain on a state space consisting of "the value of a card revealed from a deck of cards", where aces count 1 and picture cards count 10. Let \\(P\\) be randomly chosen from the range \\(1 \dots 5\\), and let \\(X_0 = P\\). Proceed as follows: define \\(X_n\\) as "the value of the \\(\sum_{i=0}^{n-1} X_i\\)-th card". Stop when the newest \\(X_n\\) would be greater than \\(52\\).

--- a/hugo/content/posts/2013-11-23-the-jean-paul-sartre-cookbook.md
+++ b/hugo/content/posts/2013-11-23-the-jean-paul-sartre-cookbook.md
@@ -7,6 +7,7 @@ comments: true
 date: "2013-11-23T00:00:00Z"
 aliases:
 - uncategorized/the-jean-paul-sartre-cookbook/
+- /wordpress/archives/506/
 title: The Jean-Paul Sartre Cookbook
 ---
 > Many thanks to the [Guru Bursill-Hall][1] for bringing this tract to my attention through his weekly History of Maths bulletins. It was originally written in 1987 by Marty Smith, according to the Internet.

--- a/hugo/content/posts/2014-02-16-rage-rage-against-the-poets-hardest-sell.md
+++ b/hugo/content/posts/2014-02-16-rage-rage-against-the-poets-hardest-sell.md
@@ -8,6 +8,7 @@ date: "2014-02-16T00:00:00Z"
 aliases:
 - /creative/rage-rage-against-the-poets-hardest-sell/
 - /rage-rage-against-the-poets-hardest-sell/
+- /wordpress/archives/563/
 title: Rage, rage against the poet’s hardest sell
 ---
 I feel that I can write a sonnet well.  

--- a/hugo/content/posts/2014-03-20-a-roundup-of-some-board-games.md
+++ b/hugo/content/posts/2014-03-20-a-roundup-of-some-board-games.md
@@ -8,6 +8,7 @@ date: "2014-03-20T00:00:00Z"
 aliases:
 - /uncategorized/a-roundup-of-some-board-games/
 - /a-roundup-of-some-board-games/
+- /wordpress/archives/576/
 title: A roundup of some board games
 ---
 It has been commented to me that it's quite hard to find out (on the Internet) what different games involve. For instance, [Agricola][1] is a game about farming (and that's easy to find out), but what you actually do while playing it is not easy to discover. Here, then, is a brief overview of some games.

--- a/hugo/content/posts/2014-03-30-how-to-discover-the-contraction-mapping-theorem.md
+++ b/hugo/content/posts/2014-03-30-how-to-discover-the-contraction-mapping-theorem.md
@@ -10,6 +10,8 @@ math: true
 aliases:
 - /mathematical_summary/proof_discovery/how-to-discover-the-contraction-mapping-theorem/
 - /how-to-discover-the-contraction-mapping-theorem/
+- /archives/584/
+- /wordpress/archives/584/
 title: How to discover the Contraction Mapping Theorem
 ---
 A little while ago I set myself the exercise of stating and proving the [Contraction Mapping Theorem][1]. It turned out that I mis-stated it in three different aspects ("contraction", "non-empty" and "complete"), but I was able to correct the statement because there were several points in the proof where it was very natural to do a certain thing (and where that thing turned out to rely on a correct statement of the theorem).

--- a/hugo/content/posts/2014-04-04-discovering-a-proof-of-heine-borel.md
+++ b/hugo/content/posts/2014-04-04-discovering-a-proof-of-heine-borel.md
@@ -10,6 +10,7 @@ math: true
 aliases:
 - /mathematical_summary/proof_discovery/discovering-a-proof-of-heine-borel/
 - /discovering-a-proof-of-heine-borel/
+- /wordpress/archives/589/
 title: Discovering a proof of Heine-Borel
 ---
 I'm running through my Analysis proofs, trying to work out which ones are genuinely hard and which follow straightforwardly from my general knowledge base. I don't find the [Heine-Borel Theorem][1] "easy" enough that I can even forget its statement and still prove it (like [I can with the Contraction Mapping Theorem][2]), but it turns out to be easy in the sense that it follows simply from all the theorems I already know. Here, then, is my attempt to discover a proof of the theorem, using as a guide all the results I know but can't necessarily prove without lots of effort.

--- a/hugo/content/posts/2014-04-07-useful-conformal-mappings.md
+++ b/hugo/content/posts/2014-04-07-useful-conformal-mappings.md
@@ -9,6 +9,7 @@ math: true
 aliases:
 - /uncategorized/useful-conformal-mappings/
 - /useful-conformal-mappings/
+- /wordpress/archives/594/
 title: Useful conformal mappings
 ---
 This post is to be a list of conformal mappings, so that I can get better at answering questions like "Find a conformal mapping from \<this domain\> to \<this domain\>". The following Mathematica code is rough-and-ready, but it is designed to demonstrate where a given region goes under a given transformation.

--- a/hugo/content/posts/2014-04-15-sample-topology-question.md
+++ b/hugo/content/posts/2014-04-15-sample-topology-question.md
@@ -10,6 +10,7 @@ math: true
 aliases:
 - /mathematical_summary/sample-topology-question/
 - /sample-topology-question/
+- /wordpress/archives/600/
 title: Sample topology question
 ---
 As part of the recent series on how I approach maths problems, I give another one here (question 14 on the Maths Tripos IB 2007 paper 4). The question is:

--- a/hugo/content/posts/2014-04-17-cayley-hamilton-theorem.md
+++ b/hugo/content/posts/2014-04-17-cayley-hamilton-theorem.md
@@ -9,6 +9,7 @@ math: true
 aliases:
 - /mathematical_summary/cayley-hamilton-theorem/
 - /cayley-hamilton-theorem/
+- /wordpress/archives/606/
 title: Cayley-Hamilton theorem
 ---
 This is to detail a much easier proof (at least, I find it so) of [Cayley-Hamilton][1] than the ones which appear on the Wikipedia page. It only applies in the case of complex vector spaces; most of the post is taken up with a proof of a lemma about complex matrices that is very useful in many contexts.

--- a/hugo/content/posts/2014-04-26-sequentially-compact-iff-compact.md
+++ b/hugo/content/posts/2014-04-26-sequentially-compact-iff-compact.md
@@ -10,6 +10,7 @@ math: true
 aliases:
 - /mathematical_summary/proof_discovery/sequentially-compact-iff-compact/
 - /sequentially-compact-iff-compact/
+- /wordpress/archives/620/
 title: Sequentially compact iff compact
 ---
 [Prof Körner][1] told us during the [IB Metric and Topological Spaces][2] course that the real meat of the course (indeed, its hardest theorem) was "a metric space is sequentially compact iff it is compact". At the moment, all I remember of this result is that one direction requires Lebesgue's lemma (whose statement I don't remember) and that the other direction is quite easy. I'm going to try and discover a proof - I'll be honest when I have to look things up.

--- a/hugo/content/posts/2014-05-03-discovering-a-proof-of-sylvesters-law-of-inertia.md
+++ b/hugo/content/posts/2014-05-03-discovering-a-proof-of-sylvesters-law-of-inertia.md
@@ -10,6 +10,7 @@ math: true
 aliases:
 - /mathematical_summary/proof_discovery/discovering-a-proof-of-sylvesters-law-of-inertia/
 - /discovering-a-proof-of-sylvesters-law-of-inertia/
+- /wordpress/archives/591/
 title: Discovering a proof of Sylvester's Law of Inertia
 ---
 *This is part of what has become a series on discovering some fairly basic mathematical results, and/or discovering their proofs. It's mostly intended so that I start finding the results intuitive - having once found a proof myself, I hope to be able to reproduce it without too much effort in the exam.*

--- a/hugo/content/posts/2014-05-26-proof-that-symmetric-matrices-are-diagonalisable.md
+++ b/hugo/content/posts/2014-05-26-proof-that-symmetric-matrices-are-diagonalisable.md
@@ -9,6 +9,7 @@ math: true
 aliases:
 - /mathematical_summary/proof-that-symmetric-matrices-are-diagonalisable/
 - /proof-that-symmetric-matrices-are-diagonalisable/
+- /wordpress/archives/658/
 title: Proof that symmetric matrices are diagonalisable
 ---
 This comes up quite frequently, but I've been stuck for an easy memory-friendly way to do this. I trawled through the 1A Vectors and Matrices course notes, and found the following mechanical proof. (It's not a discovery-proof - I looked it up.)

--- a/hugo/content/wordpress/index.html
+++ b/hugo/content/wordpress/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8">
+    <title>Redirecting&hellip;</title>
+    <link rel="canonical" href="/index.html">
+    <script>location="/index.html"</script>
+    <meta http-equiv="refresh" content="0; url=/index.html">
+    <meta name="robots" content="noindex">
+  </head>
+  <body>
+    <h1>Redirecting&hellip;</h1>
+    <a href="/index.html">Click here if you are not redirected.</a>
+  </body>
+</html>


### PR DESCRIPTION
Still missing one for /wordpress/archives/category/mathematical-summary/proof-discovery but that is a faff :( 